### PR TITLE
Add a GitHub Actions CI script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+# Builds and tests this Haskell project on "GitHub Actions"
+#
+# some docs: https://github.com/haskell/actions/tree/main/setup
+
+name: build
+on: [push]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Cache ~/.cache/cabal/packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/cabal/packages
+          key:          v1-${{ runner.os }}-cabal-packages-${{ hashFiles('*.cabal') }}
+          restore-keys: v1-${{ runner.os }}-cabal-packages-
+
+      - name: Cache ~/.local/state/cabal
+        uses: actions/cache@v3
+        with:
+          path: ~/.local/state/cabal
+          key:          v1-${{ runner.os }}-cabal-state-${{ hashFiles('*.cabal') }}
+          restore-keys: v1-${{ runner.os }}-cabal-state-${{ hashFiles('*.cabal') }}
+
+      - run: du -hd3 ~/.cache/cabal/packages ~/.local/state/cabal || true
+
+      - run: haddock --version
+      - run: ghc     --version
+      - run: cabal   --version
+      - run: haddock --version
+      - run: ghc-pkg list
+
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - run: cabal update
+      - run: cabal configure --enable-tests --enable-benchmarks --enable-coverage --enable-documentation
+      - run: cabal build
+      - run: cabal test

--- a/kudzu.cabal
+++ b/kudzu.cabal
@@ -91,7 +91,7 @@ executable kudzu
 
     -- Other library packages from which modules are imported.
     build-depends:
-        base >=4.14 && < 4.17,
+        base >=4.14 && < 4.19,
         kudzu
 
     -- Directories containing source files.


### PR DESCRIPTION
This PR adds a GitHub Actions CI script for Kudzu.

The CI script basically runs:

* `cabal build`
* `cabal test`

It takes [51s to run on a recent cache](https://github.com/rudymatela/kudzu/actions/runs/5855347592) and up to [about 5m on an empty cache](https://github.com/rudymatela/kudzu/actions/runs/5855299012).

As a bonus, this relaxes the base restriction from up to 4.17 to up to 4.19 as that was the version that was tested on CI.

I am not sure if this is something you would like to add to your project: on one hand it may help make the project easier to maintain by catching errors on CI, on the other hand it is another thing to maintain in the project.  In my own projects though, I find that maintaining a CI script is worth the effort.  I am submitting this anyway since I got to a working CI script while playing around with the project, but feel free to drop the PR if you think it would be a hassle to maintain.  (Or you can merge it and drop it later if you find it is too much of a hassle to maintain.)