### PR TITLE
report counterexample for LeanCheck failures

### DIFF
--- a/src/Kudzu.hs
+++ b/src/Kudzu.hs
@@ -56,7 +56,7 @@ testUntilSameLC n testable = do
   grabUntilNSame 0 n n (tail rs) r1
 
 examineAndCount :: ([String], Bool) -> IO Integer
-examineAndCount v = unless (snd v) (error "your code is broken") >> tixModuleCount <$> examineTix
+examineAndCount v = unless (snd v) (error $ unwords ("failed with:":fst v)) >> tixModuleCount <$> examineTix
 
 grabUntilNSame :: (Monad m, Eq a) => Int -> Int -> Int -> [m a] -> a -> m (Int, Maybe a)
 grabUntilNSame c _ 0 _ z = pure (c, Just z)

--- a/src/Kudzu.hs
+++ b/src/Kudzu.hs
@@ -56,7 +56,7 @@ testUntilSameLC n testable = do
   grabUntilNSame 0 n n (tail rs) r1
 
 examineAndCount :: ([String], Bool) -> IO Integer
-examineAndCount v = unless (snd v) (error $ unwords ("failed with:":fst v)) >> tixModuleCount <$> examineTix
+examineAndCount v = unless (snd v) (error $ unwords ("test failed with:":fst v)) >> tixModuleCount <$> examineTix
 
 grabUntilNSame :: (Monad m, Eq a) => Int -> Int -> Int -> [m a] -> a -> m (Int, Maybe a)
 grabUntilNSame c _ 0 _ z = pure (c, Just z)


### PR DESCRIPTION
For property failures found by LeanCheck, Kudzu currently reports:

```haskell
kudzu-lc.hs: your code is broken
CallStack (from HasCallStack):
  error, called at ./Kudzu.hs:59:37 in main:Kudzu
```

This PR makes it so that the "your code is broken" message is replaced by a "failed with: <counterexample>" message, hopefully making Kudzu more useful in actual testing workflows:

```haskell
kudzu-lc.hs: test failed with: [0,0]
CallStack (from HasCallStack):
  error, called at ./Kudzu.hs:59:37 in main:Kudzu
```

(The first time I ran Kudzu, I was honestly a bit confused by the "your code is broken" message.  I thought I was using it wrong, but it turns out that my property had failed as expected.  I think `test failed with:` makes it a bit more clear at a glance that the issue is a test property failure.)